### PR TITLE
Fix fabd/diablo2-runewizard#3 - add popup activation on tablet / touc…

### DIFF
--- a/src/components/RunewordPopup.vue
+++ b/src/components/RunewordPopup.vue
@@ -6,6 +6,7 @@
       left: unitPx(position.x),
       top: unitPx(position.y),
     }"
+    @click="setVisible(false)"
   >
     <h3 class="rw-RunewordPopup-title">{{ runeword.title }}</h3>
     <div class="rw-RunewordPopup-type" v-html="runeword.ttype"></div>

--- a/src/components/RunewordsTable.vue
+++ b/src/components/RunewordsTable.vue
@@ -62,6 +62,7 @@
             class="rw-Table-tdTitleSpan cursor-pointer"
             @mouseenter="onEnterRuneword($event, item)"
             @mouseleave="onLeaveRuneword()"
+            @click="onEnterRuneword($event, item)"
             >{{ item.title }}</span
           ><span v-if="item.ladder" class="rw-Md-ladder">L</span></td
         >


### PR DESCRIPTION
This fix will support touch devices.

Changes:
Added click event handlers to runewords table and runeword popup.

New behaviour:
Tapping on a runeword activates the description popup,
a tap on the description text dismisses the popup window.