### PR TITLE
Fix #9 avoid clipping Runeword popup at bottom of viewport

### DIFF
--- a/src/components/RunewordsTable.vue
+++ b/src/components/RunewordsTable.vue
@@ -259,17 +259,7 @@ export default defineComponent({
       // paranoia
       if (!ev.target) return;
 
-      let { x, y } = /**@type{Element}*/ (ev.target).getBoundingClientRect();
-
-      // don't overlap the mouseover area, avoids flickering & simplifies code
-      x = x + 50;
-      y =
-        y +
-        window.pageYOffset +
-        /**@type{HTMLElement}*/ (ev.target).offsetHeight +
-        4;
-
-      this.refPopup.setContents(runeword).moveTo(x, y).setVisible(true);
+      this.refPopup.showRuneword(runeword, /**@type HTMLElement*/ (ev.target));
     },
 
     onLeaveRuneword() {


### PR DESCRIPTION
- check the popup height against the viewport height
- move the popup vertically to fit in the viewport
- if the popup is really tall and user has increased zoom settings,
  it's possible it is too tall to fit, in this case stick it to the
  top and let it clip at the bottom of viewport
- also use a little gap, looks nicer than having the popup stick
  exactly on the edge of the viewport