### PR TITLE
Allows search by item type

### DIFF
--- a/src/components/RunewordsTable.vue
+++ b/src/components/RunewordsTable.vue
@@ -157,9 +157,14 @@ export default defineComponent({
     searchedItems() {
       const list = this.itemsBySort;
       const newList = list.filter((item) => {
-        return item.title
+        const matchesTitle = item.title
           .toLowerCase()
           .includes(this.searchTitle.toLowerCase());
+        const matchesType = !!item.ttypes.find((type) => {
+          return type.toLowerCase()
+              .includes(this.searchTitle.toLowerCase());
+        });
+        return matchesTitle || matchesType;
       });
       return newList;
     },


### PR DESCRIPTION
The search bar is really helpful, but for those like me who is still learning about runewords, it would be nice to filter by item types so we can compare the runewords.