### PR TITLE
Display runes in D2R similar to the new stash grid layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
 
   <main class="rw-Layout-row rw-Main mx-auto lg:px-4 py-4 lg:flex mb-24">
     <runes />
-    <div class="flex-1 lg:ml-16">
+    <div class="flex-1 lg:ml-8">
       <runewords />
     </div>
   </main>

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -82,7 +82,7 @@ a {
 // -------------------------------------------------------------------- */
 
 .rw-Layout-row {
-  @apply max-w-[1100px];
+  @apply max-w-[1300px];
 }
 
 .rw-Layout-goldBarSeparator {
@@ -372,28 +372,86 @@ a {
   text-decoration: none;
 }
 
-.rw-Rune {
+/* --------------------------------------------------------------------
+// STASH GRID (D2R-style rune inventory)
+// -------------------------------------------------------------------- */
+.rw-Stash {
+  @apply mx-auto;
+  max-width: 540px;
+  background: #1a1a1a;
+  border: 2px solid #3a3a3a;
+  border-radius: 4px;
+  padding: 6px;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.8);
+}
+
+.rw-StashGrid {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 2px;
+}
+
+.rw-StashCell {
   --rune-w: 40px;
   --rune-h: 40px;
 
-  @media screen and (width < 768px) {
+  @media screen and (width < 640px) {
     --rune-w: 35px;
+    --rune-h: 35px;
   }
 
-  width: var(--rune-w);
-  color: #999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #111;
+  border: 1px solid #2a2a2a;
+  padding: 4px 2px;
+  min-height: 60px;
+  color: #666;
   font-variant: small-caps;
+  font-size: 11px;
+  transition: background-color 0.15s;
 
   &:hover {
+    background: #1e1e1e;
     color: #ccc;
+    border-color: #444;
   }
 
   &.is-selected {
+    background: #111;
+    border-color: #3a3a3a;
     color: #00ff2e;
+
     .rw-RuneImg {
       opacity: 1;
     }
   }
+
+  &.rw-StashCell--empty {
+    background: #0d0d0d;
+    border-color: #1a1a1a;
+
+    &:hover {
+      background: #0d0d0d;
+      border-color: #1a1a1a;
+    }
+  }
+}
+
+.rw-StashCell-count {
+  font-size: 12px;
+  font-weight: bold;
+  font-variant: normal;
+  color: #ddd;
+  line-height: 1;
+  margin-top: 1px;
+}
+
+.rw-StashCell-name {
+  line-height: 1;
+  margin-top: 1px;
 }
 
 .rw-RuneImg {
@@ -401,6 +459,7 @@ a {
   width: var(--rune-w);
   height: var(--rune-h);
   background: url("@assets/images/runes-sprite.png") no-repeat 0 0;
+  background-size: calc(var(--rune-w) * 11) calc(var(--rune-h) * 3);
 }
 
 @import "./runes.css";

--- a/src/assets/css/runes.css
+++ b/src/assets/css/runes.css
@@ -1,37 +1,37 @@
 /* !!! do not format with prettier */
 
 .rune-El  { background-position:    0   0; }
-.rune-Eld { background-position:  -40px 0; }
-.rune-Tir { background-position:  -80px 0; }
-.rune-Nef { background-position: -120px 0; }
-.rune-Eth { background-position: -160px 0; }
-.rune-Ith { background-position: -200px 0; }
-.rune-Tal { background-position: -240px 0; }
-.rune-Ral { background-position: -280px 0; }
-.rune-Ort { background-position: -320px 0; }
-.rune-Thul{ background-position: -360px 0; }
-.rune-Amn { background-position: -400px 0; }
+.rune-Eld { background-position:  calc(var(--rune-w) * -1) 0; }
+.rune-Tir { background-position:  calc(var(--rune-w) * -2) 0; }
+.rune-Nef { background-position:  calc(var(--rune-w) * -3) 0; }
+.rune-Eth { background-position:  calc(var(--rune-w) * -4) 0; }
+.rune-Ith { background-position:  calc(var(--rune-w) * -5) 0; }
+.rune-Tal { background-position:  calc(var(--rune-w) * -6) 0; }
+.rune-Ral { background-position:  calc(var(--rune-w) * -7) 0; }
+.rune-Ort { background-position:  calc(var(--rune-w) * -8) 0; }
+.rune-Thul{ background-position:  calc(var(--rune-w) * -9) 0; }
+.rune-Amn { background-position:  calc(var(--rune-w) * -10) 0; }
 
-.rune-Sol { background-position:    0   -40px; }
-.rune-Shael{background-position:  -40px -40px; }
-.rune-Dol { background-position:  -80px -40px; }
-.rune-Hel { background-position: -120px -40px; }
-.rune-Io  { background-position: -160px -40px; }
-.rune-Lum { background-position: -200px -40px; }
-.rune-Ko  { background-position: -240px -40px; }
-.rune-Fal { background-position: -280px -40px; }
-.rune-Lem { background-position: -320px -40px; }
-.rune-Pul { background-position: -360px -40px; }
-.rune-Um  { background-position: -400px -40px; }
+.rune-Sol { background-position:    0   calc(var(--rune-h) * -1); }
+.rune-Shael{background-position:  calc(var(--rune-w) * -1) calc(var(--rune-h) * -1); }
+.rune-Dol { background-position:  calc(var(--rune-w) * -2) calc(var(--rune-h) * -1); }
+.rune-Hel { background-position:  calc(var(--rune-w) * -3) calc(var(--rune-h) * -1); }
+.rune-Io  { background-position:  calc(var(--rune-w) * -4) calc(var(--rune-h) * -1); }
+.rune-Lum { background-position:  calc(var(--rune-w) * -5) calc(var(--rune-h) * -1); }
+.rune-Ko  { background-position:  calc(var(--rune-w) * -6) calc(var(--rune-h) * -1); }
+.rune-Fal { background-position:  calc(var(--rune-w) * -7) calc(var(--rune-h) * -1); }
+.rune-Lem { background-position:  calc(var(--rune-w) * -8) calc(var(--rune-h) * -1); }
+.rune-Pul { background-position:  calc(var(--rune-w) * -9) calc(var(--rune-h) * -1); }
+.rune-Um  { background-position:  calc(var(--rune-w) * -10) calc(var(--rune-h) * -1); }
 
-.rune-Mal { background-position:    0   -80px; }
-.rune-Ist { background-position:  -40px -80px; }
-.rune-Gul { background-position:  -80px -80px; }
-.rune-Vex { background-position: -120px -80px; }
-.rune-Ohm { background-position: -160px -80px; }
-.rune-Lo  { background-position: -200px -80px; }
-.rune-Sur { background-position: -240px -80px; }
-.rune-Ber { background-position: -280px -80px; }
-.rune-Jah { background-position: -320px -80px; }
-.rune-Cham{ background-position: -360px -80px; }
-.rune-Zod { background-position: -400px -80px; }
+.rune-Mal { background-position:    0   calc(var(--rune-h) * -2); }
+.rune-Ist { background-position:  calc(var(--rune-w) * -1) calc(var(--rune-h) * -2); }
+.rune-Gul { background-position:  calc(var(--rune-w) * -2) calc(var(--rune-h) * -2); }
+.rune-Vex { background-position:  calc(var(--rune-w) * -3) calc(var(--rune-h) * -2); }
+.rune-Ohm { background-position:  calc(var(--rune-w) * -4) calc(var(--rune-h) * -2); }
+.rune-Lo  { background-position:  calc(var(--rune-w) * -5) calc(var(--rune-h) * -2); }
+.rune-Sur { background-position:  calc(var(--rune-w) * -6) calc(var(--rune-h) * -2); }
+.rune-Ber { background-position:  calc(var(--rune-w) * -7) calc(var(--rune-h) * -2); }
+.rune-Jah { background-position:  calc(var(--rune-w) * -8) calc(var(--rune-h) * -2); }
+.rune-Cham{ background-position:  calc(var(--rune-w) * -9) calc(var(--rune-h) * -2); }
+.rune-Zod { background-position:  calc(var(--rune-w) * -10) calc(var(--rune-h) * -2); }

--- a/src/components/Runes.vue
+++ b/src/components/Runes.vue
@@ -12,27 +12,25 @@
       </div>
     </div>
 
-    <div
-      class="rw-Runes lg:flex lg:justify-between lg:w-[140px] lg:mx-0 mx-[2px] md:mx-4 select-none mb-4"
-    >
-      <div
-        v-for="(runesTier, i) in runesByTier"
-        :key="i"
-        class="flex lg:block lg:w-1/3 justify-between"
-      >
-        <!-- a single rune -->
-        <div
-          v-for="rune in runesTier"
-          :key="rune.name"
-          class="rw-Rune flex-[0 0 0] mb-1"
-          :class="{
-            'is-selected': haveRunes[rune.name],
-          }"
-          @click="onToggleRune(rune.name)"
-        >
-          <div class="rw-RuneImg" :class="`rune-` + rune.name"></div>
-          <div class="text-center leading-none text-smx">{{ rune.name }}</div>
-        </div>
+    <div class="rw-Stash select-none mb-4">
+      <div class="rw-StashGrid">
+        <template v-for="(cell, i) in stashLayout" :key="i">
+          <!-- rune cell -->
+          <div
+            v-if="cell !== null"
+            class="rw-StashCell"
+            :class="{
+              'is-selected': haveRunes[cell],
+            }"
+            @click="onToggleRune(cell)"
+          >
+            <div class="rw-RuneImg" :class="`rune-` + cell"></div>
+            <div class="rw-StashCell-name">{{ cell }}</div>
+          </div>
+
+          <!-- empty cell -->
+          <div v-else class="rw-StashCell rw-StashCell--empty"></div>
+        </template>
       </div>
     </div>
   </div>
@@ -41,10 +39,24 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-import runesData, { ERuneTier } from "@/data/runes";
 import store from "@/store";
 
 import IconCancel from "@/icons/IconCancel.vue";
+
+// D2R stash layout: 9 columns x 5 rows with Mendeleev-style gaps
+// null = empty cell
+const STASH_LAYOUT: (TRuneId | null)[] = [
+  // Row 1 (9)
+  "El",   "Eld",  "Tir",  "Nef",  "Eth",  "Ith",  "Tal",  "Ral",  "Ort",
+  // Row 2 (9)
+  "Thul", "Amn",  "Sol",  "Shael", "Dol", "Hel",  "Io",   "Lum",  "Ko",
+  // Row 3 (9)
+  "Fal",  "Lem",  "Pul",  "Um",   "Mal",  "Ist",  "Gul",  "Vex",  "Ohm",
+  // Row 4 (2 + 5 empty + 2)
+  "Lo",   "Sur",  null,   null,   null,   null,   null,   "Ber",  "Jah",
+  // Row 5 (1 + 7 empty + 1)
+  "Cham", null,   null,   null,   null,   null,   null,   null,   "Zod",
+];
 
 export default defineComponent({
   name: "RunesGrid",
@@ -56,25 +68,13 @@ export default defineComponent({
   data() {
     return {
       haveRunes: store.state.haveRunes,
-      runes: runesData,
+      stashLayout: STASH_LAYOUT,
     };
   },
 
   computed: {
     isAnyRuneSelected(): boolean {
       return store.getRunes().length > 0;
-    },
-
-    runesByTier(): TRuneDef[][] {
-      const tiers = [
-        this.runes.filter((rune) => rune.tier === ERuneTier.COMMON),
-        this.runes.filter((rune) => rune.tier === ERuneTier.SEMIRARE),
-        this.runes.filter((rune) => rune.tier === ERuneTier.RARE),
-      ];
-
-      // console.log(tiers);
-
-      return tiers;
     },
   },
 


### PR DESCRIPTION
Redesign the rune selection UI as a 9-column stash grid matching the D2R Reign of the Warlock "Runes" tab (rows 1-3 fully filled, row 4 and 5 with gaps)

Replacing #47 